### PR TITLE
test: add main structure coverage

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -7,6 +7,7 @@
 /// Currently, the supported integration domain can only be one-dimensionnal, described using
 /// `f64` values (i.e. the type used for further computations). In the future, adding support
 /// for higher dimension & generic value type can be considered.
+#[derive(Debug, Clone)]
 pub enum DomainDescriptor<'a> {
     /// List of values taken by the variable on which we integrate.
     Explicit(&'a [f64]),
@@ -35,6 +36,7 @@ pub enum FunctionDescriptor {
 }
 
 /// Numerical integration method enum
+#[derive(Debug, Clone, Copy)]
 pub enum ComputeMethod {
     /// Rectangle method -- [reference](https://en.wikipedia.org/wiki/Riemann_sum)
     Rectangle,

--- a/src/structure/definitions.rs
+++ b/src/structure/definitions.rs
@@ -7,7 +7,7 @@ use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
 // ------ CONTENT
 
 /// Integral error
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum IntegraalError {
     /// One or more parameters are missing.
     MissingParameters(&'static str),

--- a/src/structure/definitions.rs
+++ b/src/structure/definitions.rs
@@ -7,7 +7,7 @@ use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
 // ------ CONTENT
 
 /// Integral error
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum IntegraalError {
     /// One or more parameters are missing.
     MissingParameters(&'static str),

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -66,6 +66,40 @@ fn missing_parameters() {
     );
 }
 
+#[test]
+fn inconsistent_parameters() {
+    let method = ComputeMethod::Rectangle;
+    let function = FunctionDescriptor::Values(vec![1., 1., 1., 1., 1., 1.]);
+    let domain = vec![0.0, 0.1, 0.2, 0.3, 0.4]; // missing the last x value
+    let domain = DomainDescriptor::Explicit(&domain);
+
+    let mut integral = Integraal::default();
+    integral.method(method).function(function).domain(domain);
+    assert_eq!(
+        integral.compute(),
+        Err(IntegraalError::InconsistentParameters(
+            "provided function and domain value slices have different lengthes"
+        ))
+    );
+
+    // this is equivalent to the first domain
+    let domain = DomainDescriptor::Uniform {
+        start: 0.,
+        step: 0.1,
+        n_step: 5,
+    };
+    let function = FunctionDescriptor::Values(vec![1., 1., 1., 1., 1., 1.]);
+
+    let mut integral = Integraal::default();
+    integral.method(method).function(function).domain(domain);
+    assert_eq!(
+        integral.compute(),
+        Err(IntegraalError::InconsistentParameters(
+            "provided function and domain value slices have different lengthes"
+        ))
+    );
+}
+
 // correct usages
 // test names follow this pattern:
 // <integral>_<FunctionDescriptorEnum>_<DomainDescriptorEnum>_<ComputeMethodEnum>

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -169,79 +169,44 @@ mod a_rectangle {
         RECTANGLE_TOLERANCE
     );
 
-    #[allow(non_snake_case)]
-    #[test]
-    fn ClosureUniform() {
-        let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
-        let domaind = DomainDescriptor::Uniform {
+    generate_test!(
+        ClosureUniform,
+        FunctionDescriptor::Closure(Box::new(f64::sin)),
+        DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,
             n_step: (1000. * std::f64::consts::PI) as usize,
-        };
-        let computem = ComputeMethod::Rectangle;
-        let mut integraal = Integraal::default();
-        let res = integraal
-            .function(functiond)
-            .domain(domaind)
-            .method(computem)
-            .compute();
-        assert!(res.is_ok());
-        assert!(
-            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-            "left: {} \nright: 2.0",
-            res.unwrap()
-        );
-    }
+        },
+        ComputeMethod::Rectangle,
+        RECTANGLE_TOLERANCE
+    );
 
-    #[allow(non_snake_case)]
-    #[test]
-    fn ValuesExplicit() {
+    generate_test!(
+        ValuesExplicit,
         let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
             .map(|step_id| step_id as f64 * STEP)
-            .collect();
-        let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
-        let domaind = DomainDescriptor::Explicit(&domain);
-        let computem = ComputeMethod::Rectangle;
-        let mut integraal = Integraal::default();
-        let res = integraal
-            .function(functiond)
-            .domain(domaind)
-            .method(computem)
-            .compute();
-        assert!(res.is_ok());
-        assert!(
-            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-            "left: {} \nright: 2.0",
-            res.unwrap()
-        );
-    }
+            .collect(),
+        FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect()),
+        DomainDescriptor::Explicit(&domain),
+        ComputeMethod::Rectangle,
+        RECTANGLE_TOLERANCE
+    );
 
-    #[allow(non_snake_case)]
-    #[test]
-    fn ValuesUniform() {
-        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
-            .map(|step_id| step_id as f64 * STEP)
-            .collect();
-        let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
-        let domaind = DomainDescriptor::Uniform {
+    generate_test!(
+        ValuesUniform,
+        FunctionDescriptor::Values(
+            (0..(1000. * std::f64::consts::PI) as usize)
+                .map(|step_id| (step_id as f64 * STEP).sin())
+                .collect()
+        ),
+        DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,
             n_step: (1000. * std::f64::consts::PI) as usize,
-        };
-        let computem = ComputeMethod::Rectangle;
-        let mut integraal = Integraal::default();
-        let res = integraal
-            .function(functiond)
-            .domain(domaind)
-            .method(computem)
-            .compute();
-        assert!(res.is_ok());
-        assert!(
-            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-            "left: {} \nright: 2.0",
-            res.unwrap()
-        );
-    }
+        },
+        ComputeMethod::Rectangle,
+        RECTANGLE_TOLERANCE
+    );
 }
 
 // integral B

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -108,31 +108,66 @@ fn inconsistent_parameters() {
 // integral A
 // y = f(x) = sin(x) from 0 to PI
 
+macro_rules! generate_test {
+    ($name: ident, $dm: stmt, $fnd: expr, $dmd: expr, $met: expr, $tol: ident) => {
+        #[allow(non_snake_case)]
+        #[test]
+        fn $name() {
+            $dm
+
+            let functiond = $fnd;
+            let domaind = $dmd;
+            let computem = $met;
+            let mut integraal = Integraal::default();
+            let res = integraal
+                .function(functiond)
+                .domain(domaind)
+                .method(computem)
+                .compute();
+            assert!(res.is_ok());
+            assert!(
+                almost_equal!(res.unwrap(), 2.0, $tol),
+                "left: {} \nright: 2.0",
+                res.unwrap()
+            );
+        }
+    };
+    ($name: ident, $fnd: expr, $dmd: expr, $met: expr, $tol: ident) => {
+        #[allow(non_snake_case)]
+        #[test]
+        fn $name() {
+            let functiond = $fnd;
+            let domaind = $dmd;
+            let computem = $met;
+            let mut integraal = Integraal::default();
+            let res = integraal
+                .function(functiond)
+                .domain(domaind)
+                .method(computem)
+                .compute();
+            assert!(res.is_ok());
+            assert!(
+                almost_equal!(res.unwrap(), 2.0, $tol),
+                "left: {} \nright: 2.0",
+                res.unwrap()
+            );
+        }
+    };
+}
+
 mod a_rectangle {
     use super::*;
 
-    #[allow(non_snake_case)]
-    #[test]
-    fn ClosureExplicit() {
-        let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
+    generate_test!(
+        ClosureExplicit,
         let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
             .map(|step_id| step_id as f64 * STEP)
-            .collect();
-        let domaind = DomainDescriptor::Explicit(&domain);
-        let computem = ComputeMethod::Rectangle;
-        let mut integraal = Integraal::default();
-        let res = integraal
-            .function(functiond)
-            .domain(domaind)
-            .method(computem)
-            .compute();
-        assert!(res.is_ok());
-        assert!(
-            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-            "left: {} \nright: 2.0",
-            res.unwrap()
-        );
-    }
+            .collect(),
+        FunctionDescriptor::Closure(Box::new(f64::sin)),
+        DomainDescriptor::Explicit(&domain),
+        ComputeMethod::Rectangle,
+        RECTANGLE_TOLERANCE
+    );
 
     #[allow(non_snake_case)]
     #[test]

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -102,6 +102,7 @@ fn inconsistent_parameters() {
 }
 
 // correct usages
+
 // test are groups per module according to the integral & the computation method
 // test names follow this pattern:
 // <FunctionDescriptorEnum><DomainDescriptorEnum>
@@ -156,6 +157,7 @@ macro_rules! generate_test {
     };
 }
 
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 mod a_rectangle {
     use super::*;
 
@@ -210,6 +212,7 @@ mod a_rectangle {
     );
 }
 
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 mod a_trapezoid {
     use super::*;
 
@@ -276,7 +279,7 @@ fn B_Closure_Explicit_Rectangle() {
     // currently requires one more value because of
     // the inconsistent sampling policy
     let domain: Vec<f64> = (0..=2001)
-        .map(|step_id| -1. + step_id as f64 * STEP)
+        .map(|step_id| -1. + f64::from(step_id) * STEP)
         .collect();
     let domaind = DomainDescriptor::Explicit(&domain);
     let computem = ComputeMethod::Rectangle;

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -101,107 +101,112 @@ fn inconsistent_parameters() {
 }
 
 // correct usages
+// test are groups per module according to the integral & the computation method
 // test names follow this pattern:
-// <integral>_<FunctionDescriptorEnum>_<DomainDescriptorEnum>_<ComputeMethodEnum>
+// <FunctionDescriptorEnum><DomainDescriptorEnum>
 
 // integral A
 // y = f(x) = sin(x) from 0 to PI
 
-#[allow(non_snake_case)]
-#[test]
-fn A_Closure_Explicit_Rectangle() {
-    let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
-    let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
-        .map(|step_id| step_id as f64 * STEP)
-        .collect();
-    let domaind = DomainDescriptor::Explicit(&domain);
-    let computem = ComputeMethod::Rectangle;
-    let mut integraal = Integraal::default();
-    let res = integraal
-        .function(functiond)
-        .domain(domaind)
-        .method(computem)
-        .compute();
-    assert!(res.is_ok());
-    assert!(
-        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-        "left: {} \nright: 2.0",
-        res.unwrap()
-    );
-}
+mod a_rectangle {
+    use super::*;
 
-#[allow(non_snake_case)]
-#[test]
-fn A_Closure_Uniform_Rectangle() {
-    let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
-    let domaind = DomainDescriptor::Uniform {
-        start: 0.,
-        step: STEP,
-        n_step: (1000. * std::f64::consts::PI) as usize,
-    };
-    let computem = ComputeMethod::Rectangle;
-    let mut integraal = Integraal::default();
-    let res = integraal
-        .function(functiond)
-        .domain(domaind)
-        .method(computem)
-        .compute();
-    assert!(res.is_ok());
-    assert!(
-        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-        "left: {} \nright: 2.0",
-        res.unwrap()
-    );
-}
+    #[allow(non_snake_case)]
+    #[test]
+    fn ClosureExplicit() {
+        let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
+        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+            .map(|step_id| step_id as f64 * STEP)
+            .collect();
+        let domaind = DomainDescriptor::Explicit(&domain);
+        let computem = ComputeMethod::Rectangle;
+        let mut integraal = Integraal::default();
+        let res = integraal
+            .function(functiond)
+            .domain(domaind)
+            .method(computem)
+            .compute();
+        assert!(res.is_ok());
+        assert!(
+            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+            "left: {} \nright: 2.0",
+            res.unwrap()
+        );
+    }
 
-#[allow(non_snake_case)]
-#[test]
-fn A_Values_Explicit_Rectangle() {
-    let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
-        .map(|step_id| step_id as f64 * STEP)
-        .collect();
-    let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
-    let domaind = DomainDescriptor::Explicit(&domain);
-    let computem = ComputeMethod::Rectangle;
-    let mut integraal = Integraal::default();
-    let res = integraal
-        .function(functiond)
-        .domain(domaind)
-        .method(computem)
-        .compute();
-    assert!(res.is_ok());
-    assert!(
-        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-        "left: {} \nright: 2.0",
-        res.unwrap()
-    );
-}
+    #[allow(non_snake_case)]
+    #[test]
+    fn ClosureUniform() {
+        let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
+        let domaind = DomainDescriptor::Uniform {
+            start: 0.,
+            step: STEP,
+            n_step: (1000. * std::f64::consts::PI) as usize,
+        };
+        let computem = ComputeMethod::Rectangle;
+        let mut integraal = Integraal::default();
+        let res = integraal
+            .function(functiond)
+            .domain(domaind)
+            .method(computem)
+            .compute();
+        assert!(res.is_ok());
+        assert!(
+            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+            "left: {} \nright: 2.0",
+            res.unwrap()
+        );
+    }
 
-#[allow(non_snake_case)]
-#[test]
-fn A_Values_Uniform_Rectangle() {
-    let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
-        .map(|step_id| step_id as f64 * STEP)
-        .collect();
-    let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
-    let domaind = DomainDescriptor::Uniform {
-        start: 0.,
-        step: STEP,
-        n_step: (1000. * std::f64::consts::PI) as usize,
-    };
-    let computem = ComputeMethod::Rectangle;
-    let mut integraal = Integraal::default();
-    let res = integraal
-        .function(functiond)
-        .domain(domaind)
-        .method(computem)
-        .compute();
-    assert!(res.is_ok());
-    assert!(
-        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
-        "left: {} \nright: 2.0",
-        res.unwrap()
-    );
+    #[allow(non_snake_case)]
+    #[test]
+    fn ValuesExplicit() {
+        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+            .map(|step_id| step_id as f64 * STEP)
+            .collect();
+        let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
+        let domaind = DomainDescriptor::Explicit(&domain);
+        let computem = ComputeMethod::Rectangle;
+        let mut integraal = Integraal::default();
+        let res = integraal
+            .function(functiond)
+            .domain(domaind)
+            .method(computem)
+            .compute();
+        assert!(res.is_ok());
+        assert!(
+            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+            "left: {} \nright: 2.0",
+            res.unwrap()
+        );
+    }
+
+    #[allow(non_snake_case)]
+    #[test]
+    fn ValuesUniform() {
+        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+            .map(|step_id| step_id as f64 * STEP)
+            .collect();
+        let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
+        let domaind = DomainDescriptor::Uniform {
+            start: 0.,
+            step: STEP,
+            n_step: (1000. * std::f64::consts::PI) as usize,
+        };
+        let computem = ComputeMethod::Rectangle;
+        let mut integraal = Integraal::default();
+        let res = integraal
+            .function(functiond)
+            .domain(domaind)
+            .method(computem)
+            .compute();
+        assert!(res.is_ok());
+        assert!(
+            almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+            "left: {} \nright: 2.0",
+            res.unwrap()
+        );
+    }
 }
 
 // integral B

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -9,6 +9,7 @@ use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor, Integraal, Inte
 // test utils
 
 const RECTANGLE_TOLERANCE: f64 = 1e-5;
+const TRAPEZOID_TOLERANCE: f64 = 1e-5;
 const STEP: f64 = 0.001;
 
 macro_rules! almost_equal {
@@ -206,6 +207,60 @@ mod a_rectangle {
         },
         ComputeMethod::Rectangle,
         RECTANGLE_TOLERANCE
+    );
+}
+
+mod a_trapezoid {
+    use super::*;
+
+    generate_test!(
+        ClosureExplicit,
+        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+            .map(|step_id| step_id as f64 * STEP)
+            .collect(),
+        FunctionDescriptor::Closure(Box::new(f64::sin)),
+        DomainDescriptor::Explicit(&domain),
+        ComputeMethod::Trapezoid,
+        TRAPEZOID_TOLERANCE
+    );
+
+    generate_test!(
+        ClosureUniform,
+        FunctionDescriptor::Closure(Box::new(f64::sin)),
+        DomainDescriptor::Uniform {
+            start: 0.,
+            step: STEP,
+            n_step: (1000. * std::f64::consts::PI) as usize,
+        },
+        ComputeMethod::Trapezoid,
+        TRAPEZOID_TOLERANCE
+    );
+
+    generate_test!(
+        ValuesExplicit,
+        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+            .map(|step_id| step_id as f64 * STEP)
+            .collect(),
+        FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect()),
+        DomainDescriptor::Explicit(&domain),
+        ComputeMethod::Trapezoid,
+        TRAPEZOID_TOLERANCE
+    );
+
+    generate_test!(
+        ValuesUniform,
+        FunctionDescriptor::Values(
+            (0..(1000. * std::f64::consts::PI) as usize)
+                .map(|step_id| (step_id as f64 * STEP).sin())
+                .collect()
+        ),
+        DomainDescriptor::Uniform {
+            start: 0.,
+            step: STEP,
+            n_step: (1000. * std::f64::consts::PI) as usize,
+        },
+        ComputeMethod::Trapezoid,
+        TRAPEZOID_TOLERANCE
     );
 }
 

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -1,4 +1,39 @@
+//! main structure tests
+
+// test utils
+
+macro_rules! almost_equal {
+    ($v1: ident, $v2: ident) => {
+        ($v1 - $v2).abs() < f64::EPSILON
+    };
+}
+
+// incorrect usages
+
 #[test]
+#[should_panic(expected = "a")]
 fn basic() {
+    assert_eq!(1 + 1, 3);
+}
+
+// correct usages
+// test names follow this pattern:
+// <integral>_<FunctionDescriptorEnum>_<DomainDescriptorEnum>_<ComputeMethodEnum>
+
+// integral A
+// y = f(x) = sin(x) from 0 to PI
+
+#[allow(non_snake_case)]
+#[test]
+fn A_Closure_Explicit_Rectangle() {
+    assert_eq!(1 + 1, 2);
+}
+
+// integral B
+// y = f(x) = x from -1 to 1
+
+#[allow(non_snake_case)]
+#[test]
+fn B_Closure_Explicit_Rectangle() {
     assert_eq!(1 + 1, 2);
 }

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -1,10 +1,19 @@
 //! main structure tests
 
+// ------ IMPORTS
+
+use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor, Integraal};
+
+// ------ CONTENT
+
 // test utils
 
+const RECTANGLE_TOLERANCE: f64 = 1e-5;
+const STEP: f64 = 0.001;
+
 macro_rules! almost_equal {
-    ($v1: ident, $v2: ident) => {
-        ($v1 - $v2).abs() < f64::EPSILON
+    ($v1: expr, $v2: expr, $tol: ident) => {
+        ($v1 - $v2).abs() < $tol
     };
 }
 
@@ -26,7 +35,24 @@ fn basic() {
 #[allow(non_snake_case)]
 #[test]
 fn A_Closure_Explicit_Rectangle() {
-    assert_eq!(1 + 1, 2);
+    let functiond = FunctionDescriptor::Closure(Box::new(|x| x.sin()));
+    let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+        .map(|step_id| step_id as f64 * STEP)
+        .collect();
+    let domaind = DomainDescriptor::Explicit(&domain);
+    let computem = ComputeMethod::Rectangle;
+    let mut integraal = Integraal::default();
+    let res = integraal
+        .function(functiond)
+        .domain(domaind)
+        .method(computem)
+        .compute();
+    assert!(res.is_ok());
+    assert!(
+        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+        "left: {} \nright: 2.0",
+        res.unwrap()
+    );
 }
 
 // integral B
@@ -35,5 +61,25 @@ fn A_Closure_Explicit_Rectangle() {
 #[allow(non_snake_case)]
 #[test]
 fn B_Closure_Explicit_Rectangle() {
-    assert_eq!(1 + 1, 2);
+    let functiond = FunctionDescriptor::Closure(Box::new(|x| x));
+    // -1 to 1, with .001 steps
+    // currently requires one more value because of
+    // the inconsistent sampling policy
+    let domain: Vec<f64> = (0..=2001)
+        .map(|step_id| -1. + step_id as f64 * STEP)
+        .collect();
+    let domaind = DomainDescriptor::Explicit(&domain);
+    let computem = ComputeMethod::Rectangle;
+    let mut integraal = Integraal::default();
+    let res = integraal
+        .function(functiond)
+        .domain(domaind)
+        .method(computem)
+        .compute();
+    assert!(res.is_ok());
+    assert!(
+        almost_equal!(res.unwrap(), 0.0, RECTANGLE_TOLERANCE),
+        "left: {} \nright: 0.0",
+        res.unwrap()
+    );
 }

--- a/src/structure/tests.rs
+++ b/src/structure/tests.rs
@@ -130,6 +130,80 @@ fn A_Closure_Explicit_Rectangle() {
     );
 }
 
+#[allow(non_snake_case)]
+#[test]
+fn A_Closure_Uniform_Rectangle() {
+    let functiond = FunctionDescriptor::Closure(Box::new(f64::sin));
+    let domaind = DomainDescriptor::Uniform {
+        start: 0.,
+        step: STEP,
+        n_step: (1000. * std::f64::consts::PI) as usize,
+    };
+    let computem = ComputeMethod::Rectangle;
+    let mut integraal = Integraal::default();
+    let res = integraal
+        .function(functiond)
+        .domain(domaind)
+        .method(computem)
+        .compute();
+    assert!(res.is_ok());
+    assert!(
+        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+        "left: {} \nright: 2.0",
+        res.unwrap()
+    );
+}
+
+#[allow(non_snake_case)]
+#[test]
+fn A_Values_Explicit_Rectangle() {
+    let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+        .map(|step_id| step_id as f64 * STEP)
+        .collect();
+    let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
+    let domaind = DomainDescriptor::Explicit(&domain);
+    let computem = ComputeMethod::Rectangle;
+    let mut integraal = Integraal::default();
+    let res = integraal
+        .function(functiond)
+        .domain(domaind)
+        .method(computem)
+        .compute();
+    assert!(res.is_ok());
+    assert!(
+        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+        "left: {} \nright: 2.0",
+        res.unwrap()
+    );
+}
+
+#[allow(non_snake_case)]
+#[test]
+fn A_Values_Uniform_Rectangle() {
+    let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
+        .map(|step_id| step_id as f64 * STEP)
+        .collect();
+    let functiond = FunctionDescriptor::Values(domain.iter().copied().map(f64::sin).collect());
+    let domaind = DomainDescriptor::Uniform {
+        start: 0.,
+        step: STEP,
+        n_step: (1000. * std::f64::consts::PI) as usize,
+    };
+    let computem = ComputeMethod::Rectangle;
+    let mut integraal = Integraal::default();
+    let res = integraal
+        .function(functiond)
+        .domain(domaind)
+        .method(computem)
+        .compute();
+    assert!(res.is_ok());
+    assert!(
+        almost_equal!(res.unwrap(), 2.0, RECTANGLE_TOLERANCE),
+        "left: {} \nright: 2.0",
+        res.unwrap()
+    );
+}
+
 // integral B
 // y = f(x) = x from -1 to 1
 


### PR DESCRIPTION
Write new tests in the dedicated submodule; They cover both correct and incorrect usages of the struct, though incorrect usages are most likely not exhaustive.

Also add some trait implementations that are required for assertions and debugging.

## Content

- Scope:
    - [x] Code
- Type of change:
    - [x] Testing
- Necessary follow-up:
    - [x] Testing: the second integral used to test is incorrectly computed because of grey areas in how discretization / rectangles / trapezoids are handled
