### PR TITLE
refactor!: replace f64 by generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ integraal-examples = { version = "0.0.2", path = "./examples" }
 # external
 rand = "0.9.0-alpha.1"
 rustversion = "1.0.15"
+num = "0.4.3"

--- a/integraal/Cargo.toml
+++ b/integraal/Cargo.toml
@@ -20,6 +20,7 @@ montecarlo = ["dep:rand"]
 # DEPS
 
 [dependencies]
+num.workspace = true
 rand = { workspace = true, features = ["small_rng"], optional = true }
 
 [build-dependencies]

--- a/integraal/src/lib.rs
+++ b/integraal/src/lib.rs
@@ -28,4 +28,4 @@ mod traits;
 
 pub use parameters::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
 pub use structure::{Integraal, IntegraalError};
-pub use traits::{DomainScalar, ImageScalar};
+pub use traits::{ImageScalar, Scalar};

--- a/integraal/src/lib.rs
+++ b/integraal/src/lib.rs
@@ -28,4 +28,4 @@ mod traits;
 
 pub use parameters::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
 pub use structure::{Integraal, IntegraalError};
-pub use traits::{ImageScalar, Scalar};
+pub use traits::Scalar;

--- a/integraal/src/lib.rs
+++ b/integraal/src/lib.rs
@@ -28,4 +28,4 @@ mod traits;
 
 pub use parameters::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
 pub use structure::{Integraal, IntegraalError};
-pub use traits::{DomainValue, ImageValue};
+pub use traits::{DomainScalar, ImageScalar};

--- a/integraal/src/lib.rs
+++ b/integraal/src/lib.rs
@@ -22,8 +22,10 @@
 
 mod parameters;
 mod structure;
+mod traits;
 
 // --- RE-EXPORTS
 
 pub use parameters::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
 pub use structure::{Integraal, IntegraalError};
+pub use traits::{DomainValue, ImageValue};

--- a/integraal/src/parameters.rs
+++ b/integraal/src/parameters.rs
@@ -1,6 +1,7 @@
 //! integral parameterization code
 
-use crate::DomainValue;
+use crate::traits::IntegratedValue;
+use crate::{DomainValue, ImageValue};
 
 /// Domain description enum
 ///
@@ -28,13 +29,20 @@ pub enum DomainDescriptor<'a, T: DomainValue> {
 ///
 /// This enum is used to provide either the values taken by the function or describe of to compute
 /// those.
-pub enum FunctionDescriptor<T: DomainValue> {
+pub enum FunctionDescriptor<X, Y, W>
+where
+    X: DomainValue,
+    Y: ImageValue<X, W>,
+    W: IntegratedValue,
+{
     /// Direct expression of the function, taking a value of the domain as input & returning the
     /// image of that value through the function.
-    Closure(Box<dyn Fn(T) -> f64>),
+    Closure(Box<dyn Fn(X) -> Y>),
     /// List of values taken by the function. The coherence with the domain description must
     /// be ensured by the user in this case.
-    Values(Vec<f64>),
+    Values(Vec<Y>),
+    /// INVALID VARIANT.
+    Invalid(std::marker::PhantomData<W>),
 }
 
 /// Numerical integration method enum

--- a/integraal/src/parameters.rs
+++ b/integraal/src/parameters.rs
@@ -1,7 +1,7 @@
 //! integral parameterization code
 
-use crate::traits::IntegratedValue;
-use crate::{DomainValue, ImageValue};
+use crate::traits::IntegratedScalar;
+use crate::{DomainScalar, ImageScalar};
 
 /// Domain description enum
 ///
@@ -11,7 +11,7 @@ use crate::{DomainValue, ImageValue};
 /// `f64` values (i.e. the type used for further computations). In the future, adding support
 /// for higher dimension & generic value type can be considered.
 #[derive(Debug, Clone)]
-pub enum DomainDescriptor<'a, T: DomainValue> {
+pub enum DomainDescriptor<'a, T: DomainScalar> {
     /// List of values taken by the variable on which we integrate.
     Explicit(&'a [T]),
     /// Description of a uniform discretization over a certain range of values.
@@ -31,9 +31,9 @@ pub enum DomainDescriptor<'a, T: DomainValue> {
 /// those.
 pub enum FunctionDescriptor<X, Y, W>
 where
-    X: DomainValue,
-    Y: ImageValue<X, W>,
-    W: IntegratedValue,
+    X: DomainScalar,
+    Y: ImageScalar<X, W>,
+    W: IntegratedScalar,
 {
     /// Direct expression of the function, taking a value of the domain as input & returning the
     /// image of that value through the function.

--- a/integraal/src/parameters.rs
+++ b/integraal/src/parameters.rs
@@ -1,7 +1,6 @@
 //! integral parameterization code
 
-use crate::traits::IntegratedScalar;
-use crate::{ImageScalar, Scalar};
+use crate::Scalar;
 
 /// Domain description enum
 ///
@@ -29,20 +28,16 @@ pub enum DomainDescriptor<'a, T: Scalar> {
 ///
 /// This enum is used to provide either the values taken by the function or describe of to compute
 /// those.
-pub enum FunctionDescriptor<X, Y, W>
+pub enum FunctionDescriptor<X>
 where
     X: Scalar,
-    Y: ImageScalar<X, W>,
-    W: IntegratedScalar,
 {
     /// Direct expression of the function, taking a value of the domain as input & returning the
     /// image of that value through the function.
-    Closure(Box<dyn Fn(X) -> Y>),
+    Closure(Box<dyn Fn(X) -> X>),
     /// List of values taken by the function. The coherence with the domain description must
     /// be ensured by the user in this case.
-    Values(Vec<Y>),
-    /// INVALID VARIANT.
-    Invalid(std::marker::PhantomData<W>),
+    Values(Vec<X>),
 }
 
 /// Numerical integration method enum

--- a/integraal/src/parameters.rs
+++ b/integraal/src/parameters.rs
@@ -1,5 +1,7 @@
 //! integral parameterization code
 
+use crate::DomainValue;
+
 /// Domain description enum
 ///
 /// This is essentially a discretization of the integrated space.
@@ -8,15 +10,15 @@
 /// `f64` values (i.e. the type used for further computations). In the future, adding support
 /// for higher dimension & generic value type can be considered.
 #[derive(Debug, Clone)]
-pub enum DomainDescriptor<'a> {
+pub enum DomainDescriptor<'a, T: DomainValue> {
     /// List of values taken by the variable on which we integrate.
-    Explicit(&'a [f64]),
+    Explicit(&'a [T]),
     /// Description of a uniform discretization over a certain range of values.
     Uniform {
         /// First value of the range
-        start: f64,
+        start: T,
         /// Step between each value of the range
-        step: f64,
+        step: T,
         /// Total number of values
         n_step: usize,
     },
@@ -26,10 +28,10 @@ pub enum DomainDescriptor<'a> {
 ///
 /// This enum is used to provide either the values taken by the function or describe of to compute
 /// those.
-pub enum FunctionDescriptor {
+pub enum FunctionDescriptor<T: DomainValue> {
     /// Direct expression of the function, taking a value of the domain as input & returning the
     /// image of that value through the function.
-    Closure(Box<dyn Fn(f64) -> f64>),
+    Closure(Box<dyn Fn(T) -> f64>),
     /// List of values taken by the function. The coherence with the domain description must
     /// be ensured by the user in this case.
     Values(Vec<f64>),

--- a/integraal/src/parameters.rs
+++ b/integraal/src/parameters.rs
@@ -1,7 +1,7 @@
 //! integral parameterization code
 
 use crate::traits::IntegratedScalar;
-use crate::{DomainScalar, ImageScalar};
+use crate::{ImageScalar, Scalar};
 
 /// Domain description enum
 ///
@@ -11,7 +11,7 @@ use crate::{DomainScalar, ImageScalar};
 /// `f64` values (i.e. the type used for further computations). In the future, adding support
 /// for higher dimension & generic value type can be considered.
 #[derive(Debug, Clone)]
-pub enum DomainDescriptor<'a, T: DomainScalar> {
+pub enum DomainDescriptor<'a, T: Scalar> {
     /// List of values taken by the variable on which we integrate.
     Explicit(&'a [T]),
     /// Description of a uniform discretization over a certain range of values.
@@ -31,7 +31,7 @@ pub enum DomainDescriptor<'a, T: DomainScalar> {
 /// those.
 pub enum FunctionDescriptor<X, Y, W>
 where
-    X: DomainScalar,
+    X: Scalar,
     Y: ImageScalar<X, W>,
     W: IntegratedScalar,
 {

--- a/integraal/src/structure/definitions.rs
+++ b/integraal/src/structure/definitions.rs
@@ -2,8 +2,8 @@
 
 // ------ IMPORTS
 
-use crate::traits::IntegratedValue;
-use crate::{ComputeMethod, DomainDescriptor, DomainValue, FunctionDescriptor, ImageValue};
+use crate::traits::IntegratedScalar;
+use crate::{ComputeMethod, DomainDescriptor, DomainScalar, FunctionDescriptor, ImageScalar};
 
 // ------ CONTENT
 
@@ -57,7 +57,7 @@ pub enum IntegraalError {
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Integraal<'a, X: DomainValue, Y: ImageValue<X, W>, W: IntegratedValue> {
+pub struct Integraal<'a, X: DomainScalar, Y: ImageScalar<X, W>, W: IntegratedScalar> {
     pub(crate) domain: Option<DomainDescriptor<'a, X>>,
     pub(crate) function: Option<FunctionDescriptor<X, Y, W>>,
     pub(crate) method: Option<ComputeMethod>,

--- a/integraal/src/structure/definitions.rs
+++ b/integraal/src/structure/definitions.rs
@@ -2,7 +2,8 @@
 
 // ------ IMPORTS
 
-use crate::{ComputeMethod, DomainDescriptor, DomainValue, FunctionDescriptor};
+use crate::traits::IntegratedValue;
+use crate::{ComputeMethod, DomainDescriptor, DomainValue, FunctionDescriptor, ImageValue};
 
 // ------ CONTENT
 
@@ -56,8 +57,8 @@ pub enum IntegraalError {
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Integraal<'a, X: DomainValue> {
+pub struct Integraal<'a, X: DomainValue, Y: ImageValue<X, W>, W: IntegratedValue> {
     pub(crate) domain: Option<DomainDescriptor<'a, X>>,
-    pub(crate) function: Option<FunctionDescriptor<X>>,
+    pub(crate) function: Option<FunctionDescriptor<X, Y, W>>,
     pub(crate) method: Option<ComputeMethod>,
 }

--- a/integraal/src/structure/definitions.rs
+++ b/integraal/src/structure/definitions.rs
@@ -2,7 +2,7 @@
 
 // ------ IMPORTS
 
-use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor};
+use crate::{ComputeMethod, DomainDescriptor, DomainValue, FunctionDescriptor};
 
 // ------ CONTENT
 
@@ -56,8 +56,8 @@ pub enum IntegraalError {
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Integraal<'a> {
-    pub(crate) domain: Option<DomainDescriptor<'a>>,
-    pub(crate) function: Option<FunctionDescriptor>,
+pub struct Integraal<'a, X: DomainValue> {
+    pub(crate) domain: Option<DomainDescriptor<'a, X>>,
+    pub(crate) function: Option<FunctionDescriptor<X>>,
     pub(crate) method: Option<ComputeMethod>,
 }

--- a/integraal/src/structure/definitions.rs
+++ b/integraal/src/structure/definitions.rs
@@ -3,7 +3,7 @@
 // ------ IMPORTS
 
 use crate::traits::IntegratedScalar;
-use crate::{ComputeMethod, DomainDescriptor, DomainScalar, FunctionDescriptor, ImageScalar};
+use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor, ImageScalar, Scalar};
 
 // ------ CONTENT
 
@@ -57,7 +57,7 @@ pub enum IntegraalError {
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Integraal<'a, X: DomainScalar, Y: ImageScalar<X, W>, W: IntegratedScalar> {
+pub struct Integraal<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> {
     pub(crate) domain: Option<DomainDescriptor<'a, X>>,
     pub(crate) function: Option<FunctionDescriptor<X, Y, W>>,
     pub(crate) method: Option<ComputeMethod>,

--- a/integraal/src/structure/definitions.rs
+++ b/integraal/src/structure/definitions.rs
@@ -2,8 +2,7 @@
 
 // ------ IMPORTS
 
-use crate::traits::IntegratedScalar;
-use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor, ImageScalar, Scalar};
+use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor, Scalar};
 
 // ------ CONTENT
 
@@ -57,8 +56,8 @@ pub enum IntegraalError {
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Integraal<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> {
+pub struct Integraal<'a, X: Scalar> {
     pub(crate) domain: Option<DomainDescriptor<'a, X>>,
-    pub(crate) function: Option<FunctionDescriptor<X, Y, W>>,
+    pub(crate) function: Option<FunctionDescriptor<X>>,
     pub(crate) method: Option<ComputeMethod>,
 }

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -4,14 +4,14 @@
 
 use crate::traits::IntegratedScalar;
 use crate::{
-    ComputeMethod, DomainDescriptor, DomainScalar, FunctionDescriptor, ImageScalar, Integraal,
-    IntegraalError,
+    ComputeMethod, DomainDescriptor, FunctionDescriptor, ImageScalar, Integraal, IntegraalError,
+    Scalar,
 };
 use num::abs;
 
 // ------ CONTENT
 
-impl<'a, X: DomainScalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, Y, W> {
+impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, Y, W> {
     /// Set the domain descriptor.
     pub fn domain(&mut self, domain_descriptor: DomainDescriptor<'a, X>) -> &mut Self {
         self.domain = Some(domain_descriptor);

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -2,19 +2,21 @@
 
 // ------ IMPORTS
 
-use crate::{ComputeMethod, DomainDescriptor, FunctionDescriptor, Integraal, IntegraalError};
+use crate::{
+    ComputeMethod, DomainDescriptor, DomainValue, FunctionDescriptor, Integraal, IntegraalError,
+};
 
 // ------ CONTENT
 
-impl<'a> Integraal<'a> {
+impl<'a, T: DomainValue> Integraal<'a, T> {
     /// Set the domain descriptor.
-    pub fn domain(&mut self, domain_descriptor: DomainDescriptor<'a>) -> &mut Self {
+    pub fn domain(&mut self, domain_descriptor: DomainDescriptor<'a, T>) -> &mut Self {
         self.domain = Some(domain_descriptor);
         self
     }
 
     /// Set the function descriptor.
-    pub fn function(&mut self, function_descriptor: FunctionDescriptor) -> &mut Self {
+    pub fn function(&mut self, function_descriptor: FunctionDescriptor<T>) -> &mut Self {
         self.function = Some(function_descriptor);
         self
     }

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -6,6 +6,7 @@ use crate::{
     ComputeMethod, DomainDescriptor, FunctionDescriptor, Integraal, IntegraalError, Scalar,
 };
 use num::abs;
+use std::ops::Deref;
 
 // ------ CONTENT
 
@@ -28,7 +29,11 @@ impl<'a, X: Scalar> Integraal<'a, X> {
         self
     }
 
-    #[allow(clippy::missing_errors_doc, clippy::too_many_lines)]
+    #[allow(
+        clippy::missing_errors_doc,
+        clippy::missing_panics_doc,
+        clippy::too_many_lines
+    )]
     /// This method attempts to compute the integral. If it is successful, it will clear the
     /// internal [`FunctionDescriptor`] object before returning the result.
     ///
@@ -138,7 +143,7 @@ impl<'a, X: Scalar> Integraal<'a, X> {
                 Some(ComputeMethod::Trapezoid) => (1..args.len())
                     .map(|idx| {
                         let step = args[idx] - args[idx - 1];
-                        let y1 = closure.clone()(args[idx - 1]);
+                        let y1 = closure.deref()(args[idx - 1]);
                         let y2 = closure(args[idx]);
                         (y1.min(y2) + (y1 - y2).abs() / X::from_f32(2.0).unwrap()) * step
                     })
@@ -175,7 +180,7 @@ impl<'a, X: Scalar> Integraal<'a, X> {
                         .map(|step_id| {
                             let x1 = *start + *step * X::from_usize(step_id - 1).unwrap();
                             let x2 = *start + *step * X::from_usize(step_id).unwrap();
-                            let y1 = closure.clone()(x1);
+                            let y1 = closure.deref()(x1);
                             let y2 = closure(x2);
                             (y1.min(y2) + (y1 - y2).abs() / X::from_f32(2.0).unwrap()) * *step
                         })

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -2,16 +2,14 @@
 
 // ------ IMPORTS
 
-use crate::traits::IntegratedScalar;
 use crate::{
-    ComputeMethod, DomainDescriptor, FunctionDescriptor, ImageScalar, Integraal, IntegraalError,
-    Scalar,
+    ComputeMethod, DomainDescriptor, FunctionDescriptor, Integraal, IntegraalError, Scalar,
 };
 use num::abs;
 
 // ------ CONTENT
 
-impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, Y, W> {
+impl<'a, X: Scalar> Integraal<'a, X> {
     /// Set the domain descriptor.
     pub fn domain(&mut self, domain_descriptor: DomainDescriptor<'a, X>) -> &mut Self {
         self.domain = Some(domain_descriptor);
@@ -19,7 +17,7 @@ impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, 
     }
 
     /// Set the function descriptor.
-    pub fn function(&mut self, function_descriptor: FunctionDescriptor<X, Y, W>) -> &mut Self {
+    pub fn function(&mut self, function_descriptor: FunctionDescriptor<X>) -> &mut Self {
         self.function = Some(function_descriptor);
         self
     }
@@ -39,7 +37,7 @@ impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, 
     /// This method returns a `Result` taking the following values:
     /// - `Ok(f64)` -- The computation was successfuly done
     /// - `Err(IntegraalError)` -- The computation failed for the reason specified by the enum.
-    pub fn compute(&mut self) -> Result<W, IntegraalError> {
+    pub fn compute(&mut self) -> Result<X, IntegraalError> {
         if self.domain.is_none() | self.function.is_none() | self.method.is_none() {
             return Err(IntegraalError::MissingParameters(
                 "one or more parameter is missing",
@@ -73,7 +71,7 @@ impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, 
                             let step = args[idx] - args[idx - 1];
                             let y1 = vals[idx - 1];
                             let y2 = vals[idx];
-                            (y1.min(y2) + abs(y1 - y2) / Y::from_f32(2.0).unwrap()) * step
+                            (y1.min(y2) + abs(y1 - y2) / X::from_f32(2.0).unwrap()) * step
                         })
                         .sum(),
                     #[cfg(feature = "montecarlo")]
@@ -111,7 +109,7 @@ impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, 
                         .map(|step_id| {
                             let y1 = vals[step_id - 1];
                             let y2 = vals[step_id];
-                            (y1.min(y2) + (y1 - y2).abs() / Y::from_f32(2.0).unwrap()) * *step
+                            (y1.min(y2) + (y1 - y2).abs() / X::from_f32(2.0).unwrap()) * *step
                         })
                         .sum(),
                     #[cfg(feature = "montecarlo")]
@@ -142,7 +140,7 @@ impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, 
                         let step = args[idx] - args[idx - 1];
                         let y1 = closure.clone()(args[idx - 1]);
                         let y2 = closure(args[idx]);
-                        (y1.min(y2) + (y1 - y2).abs() / Y::from_f32(2.0).unwrap()) * step
+                        (y1.min(y2) + (y1 - y2).abs() / X::from_f32(2.0).unwrap()) * step
                     })
                     .sum(),
                 #[cfg(feature = "montecarlo")]
@@ -179,7 +177,7 @@ impl<'a, X: Scalar, Y: ImageScalar<X, W>, W: IntegratedScalar> Integraal<'a, X, 
                             let x2 = *start + *step * X::from_usize(step_id).unwrap();
                             let y1 = closure.clone()(x1);
                             let y2 = closure(x2);
-                            (y1.min(y2) + (y1 - y2).abs() / Y::from_f32(2.0).unwrap()) * *step
+                            (y1.min(y2) + (y1 - y2).abs() / X::from_f32(2.0).unwrap()) * *step
                         })
                         .sum(),
                     #[cfg(feature = "montecarlo")]

--- a/integraal/src/structure/tests.rs
+++ b/integraal/src/structure/tests.rs
@@ -20,15 +20,15 @@ macro_rules! almost_equal {
 
 macro_rules! generate_sample_descriptors {
     ($f: ident, $d: ident, $c: ident) => {
-        let $f = FunctionDescriptor::Closure(Box::new(|x| x));
-        let $d = DomainDescriptor::Explicit(&[]);
-        let $c = ComputeMethod::RectangleLeft;
+        let $f: FunctionDescriptor<f64, f64, f64> = FunctionDescriptor::Closure(Box::new(|x| x));
+        let $d: DomainDescriptor<'_, f64> = DomainDescriptor::Explicit(&[]);
+        let $c: ComputeMethod = ComputeMethod::RectangleLeft;
     };
 }
 
 macro_rules! generate_missing {
     ($a: ident, $b: ident) => {
-        let mut integral = Integraal::default();
+        let mut integral: Integraal<'_, f64, f64, f64> = Integraal::default();
         integral.$a($a).$b($b);
         assert_eq!(
             integral.compute(),
@@ -57,7 +57,7 @@ fn missing_parameters() {
     generate_missing!(function, domain);
 
     // missing all but one
-    let mut integral = Integraal::default();
+    let mut integral: Integraal<'_, f64, f64, f64> = Integraal::default();
     integral.method(method);
     assert_eq!(
         integral.compute(),

--- a/integraal/src/structure/tests.rs
+++ b/integraal/src/structure/tests.rs
@@ -20,7 +20,7 @@ macro_rules! almost_equal {
 
 macro_rules! generate_sample_descriptors {
     ($f: ident, $d: ident, $c: ident) => {
-        let $f: FunctionDescriptor<f64, f64, f64> = FunctionDescriptor::Closure(Box::new(|x| x));
+        let $f: FunctionDescriptor<f64> = FunctionDescriptor::Closure(Box::new(|x| x));
         let $d: DomainDescriptor<'_, f64> = DomainDescriptor::Explicit(&[]);
         let $c: ComputeMethod = ComputeMethod::RectangleLeft;
     };
@@ -28,7 +28,7 @@ macro_rules! generate_sample_descriptors {
 
 macro_rules! generate_missing {
     ($a: ident, $b: ident) => {
-        let mut integral: Integraal<'_, f64, f64, f64> = Integraal::default();
+        let mut integral: Integraal<'_, f64> = Integraal::default();
         integral.$a($a).$b($b);
         assert_eq!(
             integral.compute(),
@@ -57,7 +57,7 @@ fn missing_parameters() {
     generate_missing!(function, domain);
 
     // missing all but one
-    let mut integral: Integraal<'_, f64, f64, f64> = Integraal::default();
+    let mut integral: Integraal<'_, f64> = Integraal::default();
     integral.method(method);
     assert_eq!(
         integral.compute(),

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -1,5 +1,12 @@
 //! module doc
 
-pub trait DomainValue {}
+pub trait DomainValue: Clone + Copy + std::ops::Sub<Output = Self> {}
 
-pub trait ImageValue {}
+impl<X: Clone + Copy + std::ops::Sub<Output = Self>> DomainValue for X {}
+
+pub trait ImageValue<X: DomainValue, W: IntegratedValue>:
+    Clone + Copy + std::ops::Mul<X, Output = W>
+{
+}
+
+pub trait IntegratedValue: Clone + Copy {}

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -1,6 +1,6 @@
 //! module doc
 
-/// Scalar domain value trait.
+/// Scalar value trait.
 ///
 /// This trait is automatically implemented for all types implementing its requirements.
 pub trait Scalar:

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -1,0 +1,5 @@
+//! module doc
+
+pub trait DomainValue {}
+
+pub trait ImageValue {}

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -5,7 +5,7 @@ pub trait DomainValue: Clone + Copy + std::ops::Sub<Output = Self> {}
 impl<X: Clone + Copy + std::ops::Sub<Output = Self>> DomainValue for X {}
 
 pub trait ImageValue<X: DomainValue, W: IntegratedValue>:
-    Clone + Copy + std::ops::Mul<X, Output = W>
+    Clone + Copy + std::ops::Mul<X, Output = W> + std::ops::Sub<Output = Self>
 {
 }
 

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -3,48 +3,27 @@
 /// Scalar domain value trait.
 ///
 /// This trait is automatically implemented for all types implementing its requirements.
-pub trait DomainScalar:
-    Clone + Copy + std::ops::Sub<Output = Self> + num::Float + num::Signed + num::FromPrimitive
-{
-}
-
-impl<
-        X: Clone + Copy + std::ops::Sub<Output = Self> + num::Float + num::Signed + num::FromPrimitive,
-    > DomainScalar for X
-{
-}
-
-/// Scalar image value trait.
-///
-/// This trait is automatically implemented for all types implementing its requirements.
-pub trait ImageScalar<X: DomainScalar, W: IntegratedScalar>:
+pub trait Scalar:
     Clone
     + Copy
-    + std::ops::Mul<X, Output = W>
-    + std::ops::Sub<Output = Self>
     + num::Float
     + num::Signed
     + num::FromPrimitive
+    + std::ops::Sub<Output = Self>
+    + std::ops::Mul<Output = Self>
+    + std::iter::Sum
 {
 }
 
 impl<
-        X: DomainScalar,
-        Y: Clone
+        X: Clone
             + Copy
-            + std::ops::Mul<X, Output = W>
-            + std::ops::Sub<Output = Self>
             + num::Float
             + num::Signed
-            + num::FromPrimitive,
-        W: IntegratedScalar,
-    > ImageScalar<X, W> for Y
+            + num::FromPrimitive
+            + std::ops::Sub<Output = Self>
+            + std::ops::Mul<Output = Self>
+            + std::iter::Sum,
+    > Scalar for X
 {
 }
-
-/// Scalar post-integration value trait.
-///
-/// This trait is automatically implemented for all types implementing its requirements.
-pub trait IntegratedScalar: Clone + Copy + std::iter::Sum {}
-
-impl<W: Clone + Copy + std::iter::Sum> IntegratedScalar for W {}

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -1,5 +1,8 @@
 //! module doc
 
+/// Scalar domain value trait.
+///
+/// This trait is automatically implemented for all types implementing its requirements.
 pub trait DomainScalar:
     Clone + Copy + std::ops::Sub<Output = Self> + num::Float + num::Signed + num::FromPrimitive
 {
@@ -11,6 +14,9 @@ impl<
 {
 }
 
+/// Scalar image value trait.
+///
+/// This trait is automatically implemented for all types implementing its requirements.
 pub trait ImageScalar<X: DomainScalar, W: IntegratedScalar>:
     Clone
     + Copy
@@ -36,6 +42,9 @@ impl<
 {
 }
 
+/// Scalar post-integration value trait.
+///
+/// This trait is automatically implemented for all types implementing its requirements.
 pub trait IntegratedScalar: Clone + Copy + std::iter::Sum {}
 
 impl<W: Clone + Copy + std::iter::Sum> IntegratedScalar for W {}

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -37,3 +37,5 @@ impl<
 }
 
 pub trait IntegratedScalar: Clone + Copy + std::iter::Sum {}
+
+impl<W: Clone + Copy + std::iter::Sum> IntegratedScalar for W {}

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -1,12 +1,39 @@
 //! module doc
 
-pub trait DomainValue: Clone + Copy + std::ops::Sub<Output = Self> {}
-
-impl<X: Clone + Copy + std::ops::Sub<Output = Self>> DomainValue for X {}
-
-pub trait ImageValue<X: DomainValue, W: IntegratedValue>:
-    Clone + Copy + std::ops::Mul<X, Output = W> + std::ops::Sub<Output = Self>
+pub trait DomainScalar:
+    Clone + Copy + std::ops::Sub<Output = Self> + num::Float + num::Signed + num::FromPrimitive
 {
 }
 
-pub trait IntegratedValue: Clone + Copy {}
+impl<
+        X: Clone + Copy + std::ops::Sub<Output = Self> + num::Float + num::Signed + num::FromPrimitive,
+    > DomainScalar for X
+{
+}
+
+pub trait ImageScalar<X: DomainScalar, W: IntegratedScalar>:
+    Clone
+    + Copy
+    + std::ops::Mul<X, Output = W>
+    + std::ops::Sub<Output = Self>
+    + num::Float
+    + num::Signed
+    + num::FromPrimitive
+{
+}
+
+impl<
+        X: DomainScalar,
+        Y: Clone
+            + Copy
+            + std::ops::Mul<X, Output = W>
+            + std::ops::Sub<Output = Self>
+            + num::Float
+            + num::Signed
+            + num::FromPrimitive,
+        W: IntegratedScalar,
+    > ImageScalar<X, W> for Y
+{
+}
+
+pub trait IntegratedScalar: Clone + Copy + std::iter::Sum {}


### PR DESCRIPTION
## Summary

Add three new traits that are automatically implemented for all types fitting their requirements: `DomainScalar`, `ImageScalar` and `ImageScalar`. They differ in requirements (those are entirely defined by the necessity for implementation) and are distinguished by some vague notion of homogeneity.

To-Do:
- [x] ~Rewrite tests to cover `f64`, `f32`, and mixed type integrals~ will do in another PR where I complete tests
- [ ] Correct the `almost_equal` macros ([ref](https://floating-point-gui.de/errors/comparison/))

## Content

- Scope:
    - [x] Code
- Type of change:
    - [x] Refactor
- Other:
    - [x] Breaking change
    - [x] New dependency: `num`
