### PR TITLE
feat: add epsilon computation to the main structure

### DIFF
--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -218,6 +218,31 @@ impl<'a, X: Scalar> Integraal<'a, X> {
                 "one or more parameter is missing",
             ));
         }
-        todo!()
+        if let Some(DomainDescriptor::Uniform {
+            start,
+            step,
+            n_step,
+        }) = self.domain
+        {
+            // ref: https://en.wikipedia.org/wiki/Riemann_sum#Riemann_summation_methods
+            let res = match self.method {
+                Some(ComputeMethod::RectangleLeft) | Some(ComputeMethod::RectangleRight) => {
+                    todo!()
+                }
+                Some(ComputeMethod::Trapezoid) => {
+                    todo!()
+                }
+                #[cfg(feature = "montecarlo")]
+                Some(ComputeMethod::MonteCarlo { .. }) => {
+                    todo!()
+                }
+                None => unreachable!(),
+            };
+            Ok(res)
+        } else {
+            Err(IntegraalError::InconsistentParameters(
+                "numerical error computation in not supported for non-uniform domains",
+            ))
+        }
     }
 }

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -205,7 +205,7 @@ impl<'a, X: Scalar> Integraal<'a, X> {
     )]
     /// This method attempts to compute the numerical error one can expect from the approximation.
     ///
-    /// TODO: add ref to error formulae
+    /// Error formulae were taken from the respective methods' Wikipedia pages.
     ///
     /// # Return / Errors
     ///

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -197,4 +197,27 @@ impl<'a, X: Scalar> Integraal<'a, X> {
         self.function = None;
         Ok(res)
     }
+
+    #[allow(
+        clippy::missing_errors_doc,
+        clippy::missing_panics_doc,
+        clippy::too_many_lines
+    )]
+    /// This method attempts to compute the numerical error one can expect from the approximation.
+    ///
+    /// TODO: add ref to error formulae
+    ///
+    /// # Return / Errors
+    ///
+    /// This method returns a `Result` taking the following values:
+    /// - `Ok(X: Scalar)` -- The computation was successfuly done
+    /// - `Err(IntegraalError)` -- The computation failed for the reason specified by the enum.
+    pub fn compute_error(&mut self) -> Result<X, IntegraalError> {
+        if self.domain.is_none() | self.function.is_none() | self.method.is_none() {
+            return Err(IntegraalError::MissingParameters(
+                "one or more parameter is missing",
+            ));
+        }
+        todo!()
+    }
 }

--- a/integraal/src/traits.rs
+++ b/integraal/src/traits.rs
@@ -1,4 +1,4 @@
-//! module doc
+//! Common traits implementation
 
 /// Scalar value trait.
 ///


### PR DESCRIPTION
## Summary

Add a new method to the main structure: `Integraal::compute_error`. This method computes the error one can expect from the approximation of the integral. Note that the value should be taken with a grain of salt since there is some derivative approximation involved.

## Content

- Scope:
    - [x] Code
- Type of change:
    - [x] New feature(s)
- Necessary follow-up:
    - [x] Needs testing: test should make use of this to adjust their tolerance
