### PR TITLE
refactor: replace `&'a [T]` with `Vec<T>` in explicit domain descriptors

### DIFF
--- a/integraal/src/parameters.rs
+++ b/integraal/src/parameters.rs
@@ -10,16 +10,15 @@ use crate::Scalar;
 /// is automatially implemented for types satisfying its requirements. In the future, adding support for
 /// higher dimension can be considered.
 #[derive(Debug, Clone)]
-pub enum DomainDescriptor<'a, T: Scalar> {
-    // FIXME: change to a vector
+pub enum DomainDescriptor<X: Scalar> {
     /// List of values taken by the variable on which we integrate.
-    Explicit(&'a [T]),
+    Explicit(Vec<X>),
     /// Description of a uniform discretization over a certain range of values.
     Uniform {
         /// First value of the range
-        start: T,
+        start: X,
         /// Step between each value of the range
-        step: T,
+        step: X,
         /// Total number of values
         n_step: usize,
     },

--- a/integraal/src/structure/definitions.rs
+++ b/integraal/src/structure/definitions.rs
@@ -67,9 +67,9 @@ pub enum IntegraalError {
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Integraal<'a, X: Scalar> {
+pub struct Integraal<X: Scalar> {
     /// Domain over which the function is integrated.
-    pub(crate) domain: Option<DomainDescriptor<'a, X>>,
+    pub(crate) domain: Option<DomainDescriptor<X>>,
     /// Function to integrate.
     pub(crate) function: Option<FunctionDescriptor<X>>,
     /// Numerical integration method used for value approximation.

--- a/integraal/src/structure/implementations.rs
+++ b/integraal/src/structure/implementations.rs
@@ -10,10 +10,10 @@ use rand::Rng;
 
 // ------ CONTENT
 
-impl<'a, X: Scalar> Integraal<'a, X> {
+impl<X: Scalar> Integraal<X> {
     /// Set the domain descriptor.
     #[must_use = "unused builder struct - please remove this call"]
-    pub fn domain(mut self, domain_descriptor: DomainDescriptor<'a, X>) -> Self {
+    pub fn domain(mut self, domain_descriptor: DomainDescriptor<X>) -> Self {
         self.domain = Some(domain_descriptor);
         self
     }

--- a/integraal/src/tests/function_a.rs
+++ b/integraal/src/tests/function_a.rs
@@ -22,16 +22,17 @@ mod double {
 
     all_tests!(
         f64,
-        let domain: Vec<f64> = (0..(std::f64::consts::PI * 1000.) as usize)
-            .map(|step_id| step_id as f64 * STEP)
-            .collect(),
         FunctionDescriptor::Closure(Box::new(f64::sin)),
         FunctionDescriptor::Values(
             (0..(1000. * std::f64::consts::PI) as usize)
                 .map(|step_id| (step_id as f64 * STEP).sin())
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit(
+            (0..(std::f64::consts::PI * 1000.) as usize)
+                .map(|step_id| step_id as f64 * STEP)
+                .collect()
+        ),
         DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,
@@ -55,16 +56,17 @@ mod simple {
 
     all_tests!(
         f32,
-        let domain: Vec<f32> = (0..(std::f32::consts::PI * 1000.) as usize)
-            .map(|step_id| step_id as f32 * STEP)
-            .collect(),
         FunctionDescriptor::Closure(Box::new(f32::sin)),
         FunctionDescriptor::Values(
             (0..(1000. * std::f32::consts::PI) as usize)
                 .map(|step_id| (step_id as f32 * STEP).sin())
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit(
+            (0..(std::f32::consts::PI * 1000.) as usize)
+                .map(|step_id| step_id as f32 * STEP)
+                .collect()
+        ),
         DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,

--- a/integraal/src/tests/function_b.rs
+++ b/integraal/src/tests/function_b.rs
@@ -24,28 +24,32 @@ mod double {
 
     all_tests!(
         f64,
-        let domain: Vec<f64> = (0..3000)
-            .map(|step_id| f64::from(step_id) * STEP)
-            .collect(),
-        FunctionDescriptor::Closure(
-            Box::new(|x|
-                if      (0.0..1.0).contains(&x) { x }
-                else if (1.0..2.0).contains(&x) { 1.0 }
-                else if (2.0..3.0).contains(&x) { 3.0 - x }
-                else { 0.0 })
-        ),
+        FunctionDescriptor::Closure(Box::new(|x| if (0.0..1.0).contains(&x) {
+            x
+        } else if (1.0..2.0).contains(&x) {
+            1.0
+        } else if (2.0..3.0).contains(&x) {
+            3.0 - x
+        } else {
+            0.0
+        })),
         FunctionDescriptor::Values(
             (0..3000)
                 .map(|step_id| {
                     let x = f64::from(step_id) * STEP;
-                    if      (0.0..1.0).contains(&x) { x }
-                    else if (1.0..2.0).contains(&x) { 1.0 }
-                    else if (2.0..3.0).contains(&x) { 3.0 - x }
-                    else { 0.0 }
+                    if (0.0..1.0).contains(&x) {
+                        x
+                    } else if (1.0..2.0).contains(&x) {
+                        1.0
+                    } else if (2.0..3.0).contains(&x) {
+                        3.0 - x
+                    } else {
+                        0.0
+                    }
                 })
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit((0..3000).map(|step_id| f64::from(step_id) * STEP).collect()),
         DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,
@@ -69,28 +73,32 @@ mod simple {
 
     all_tests!(
         f32,
-        let domain: Vec<f32> = (0..3000)
-            .map(|step_id| step_id as f32 * STEP)
-            .collect(),
-        FunctionDescriptor::Closure(
-            Box::new(|x: f32|
-                if x < 1.0 { x }
-                else if x < 2.0 { 1.0 }
-                else if x < 3.0 { 3.0 - x }
-                else { 0.0 })
-        ),
+        FunctionDescriptor::Closure(Box::new(|x: f32| if x < 1.0 {
+            x
+        } else if x < 2.0 {
+            1.0
+        } else if x < 3.0 {
+            3.0 - x
+        } else {
+            0.0
+        })),
         FunctionDescriptor::Values(
             (0..3000)
                 .map(|step_id| {
                     let x = step_id as f32 * STEP;
-                    if x < 1.0 { x }
-                    else if x < 2.0 { 1.0 }
-                    else if x < 3.0 { 3.0 - x }
-                    else { 0.0 }
+                    if x < 1.0 {
+                        x
+                    } else if x < 2.0 {
+                        1.0
+                    } else if x < 3.0 {
+                        3.0 - x
+                    } else {
+                        0.0
+                    }
                 })
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit((0..3000).map(|step_id| step_id as f32 * STEP).collect()),
         DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,

--- a/integraal/src/tests/function_c.rs
+++ b/integraal/src/tests/function_c.rs
@@ -24,26 +24,28 @@ mod double {
 
     all_tests!(
         f64,
-        let domain: Vec<f64> = (0..2000)
-            .map(|step_id| f64::from(step_id) * STEP)
-            .collect(),
-        FunctionDescriptor::Closure(
-            Box::new(|x|
-                if x < 1.0 { 0.0 }
-                else if x < 1.5 { 1.0 }
-                else { 0.0 })
-        ),
+        FunctionDescriptor::Closure(Box::new(|x| if x < 1.0 {
+            0.0
+        } else if x < 1.5 {
+            1.0
+        } else {
+            0.0
+        })),
         FunctionDescriptor::Values(
             (0..2000)
                 .map(|step_id| {
                     let x = f64::from(step_id) * STEP;
-                    if x < 1.0 { 0.0 }
-                    else if x < 1.5 { 1.0 }
-                    else { 0.0 }
+                    if x < 1.0 {
+                        0.0
+                    } else if x < 1.5 {
+                        1.0
+                    } else {
+                        0.0
+                    }
                 })
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit((0..2000).map(|step_id| f64::from(step_id) * STEP).collect()),
         DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,
@@ -67,26 +69,28 @@ mod simple {
 
     all_tests!(
         f32,
-        let domain: Vec<f32> = (0..2000)
-            .map(|step_id| step_id as f32 * STEP)
-            .collect(),
-        FunctionDescriptor::Closure(
-            Box::new(|x|
-                if x < 1.0 { 0.0 }
-                else if x < 1.5 { 1.0 }
-                else { 0.0 })
-        ),
+        FunctionDescriptor::Closure(Box::new(|x| if x < 1.0 {
+            0.0
+        } else if x < 1.5 {
+            1.0
+        } else {
+            0.0
+        })),
         FunctionDescriptor::Values(
             (0..2000)
                 .map(|step_id| {
                     let x = step_id as f32 * STEP;
-                    if x < 1.0 { 0.0 }
-                    else if x < 1.5 { 1.0 }
-                    else { 0.0 }
+                    if x < 1.0 {
+                        0.0
+                    } else if x < 1.5 {
+                        1.0
+                    } else {
+                        0.0
+                    }
                 })
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit((0..2000).map(|step_id| step_id as f32 * STEP).collect()),
         DomainDescriptor::Uniform {
             start: 0.,
             step: STEP,

--- a/integraal/src/tests/function_d.rs
+++ b/integraal/src/tests/function_d.rs
@@ -23,16 +23,17 @@ mod double {
 
     all_tests!(
         f64,
-        let domain: Vec<f64> = (-4000..4000)
-            .map(|step_id| f64::from(step_id) * STEP)
-            .collect(),
         FunctionDescriptor::Closure(Box::new(|x: f64| x.powi(2))),
         FunctionDescriptor::Values(
             (-4000..4000)
                 .map(|step_id| (f64::from(step_id) * STEP).powi(2))
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit(
+            (-4000..4000)
+                .map(|step_id| f64::from(step_id) * STEP)
+                .collect()
+        ),
         DomainDescriptor::Uniform {
             start: -4.,
             step: STEP,
@@ -56,16 +57,13 @@ mod simple {
 
     all_tests!(
         f32,
-        let domain: Vec<f32> = (-4000..4000)
-            .map(|step_id| step_id as f32 * STEP)
-            .collect(),
         FunctionDescriptor::Closure(Box::new(|x: f32| x.powi(2))),
         FunctionDescriptor::Values(
             (-4000..4000)
                 .map(|step_id| (step_id as f32 * STEP).powi(2))
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit((-4000..4000).map(|step_id| step_id as f32 * STEP).collect()),
         DomainDescriptor::Uniform {
             start: -4.,
             step: STEP,

--- a/integraal/src/tests/function_e.rs
+++ b/integraal/src/tests/function_e.rs
@@ -23,16 +23,17 @@ mod double {
 
     all_tests!(
         f64,
-        let domain: Vec<f64> = (-4000..4000)
-            .map(|step_id| f64::from(step_id) * STEP)
-            .collect(),
         FunctionDescriptor::Closure(Box::new(|x: f64| x.powi(2))),
         FunctionDescriptor::Values(
             (-4000..4000)
                 .map(|step_id| (f64::from(step_id) * STEP).powi(2))
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit(
+            (-4000..4000)
+                .map(|step_id| f64::from(step_id) * STEP)
+                .collect()
+        ),
         DomainDescriptor::Uniform {
             start: -4.,
             step: STEP,
@@ -56,16 +57,13 @@ mod simple {
 
     all_tests!(
         f32,
-        let domain: Vec<f32> = (-4000..4000)
-            .map(|step_id| step_id as f32 * STEP)
-            .collect(),
         FunctionDescriptor::Closure(Box::new(|x: f32| x.powi(2))),
         FunctionDescriptor::Values(
             (-4000..4000)
                 .map(|step_id| (step_id as f32 * STEP).powi(2))
                 .collect()
         ),
-        DomainDescriptor::Explicit(&domain),
+        DomainDescriptor::Explicit((-4000..4000).map(|step_id| step_id as f32 * STEP).collect()),
         DomainDescriptor::Uniform {
             start: -4.,
             step: STEP,

--- a/integraal/src/tests/incorrect.rs
+++ b/integraal/src/tests/incorrect.rs
@@ -20,7 +20,7 @@ fn missing_parameters() {
     generate_missing!(function, domain);
 
     // missing all but one
-    let mut integral: Integraal<'_, f64> = Integraal::default().method(method);
+    let mut integral: Integraal<f64> = Integraal::default().method(method);
     assert_eq!(
         integral.compute(),
         Err(IntegraalError::MissingParameters(
@@ -33,8 +33,7 @@ fn missing_parameters() {
 fn inconsistent_parameters() {
     let method = ComputeMethod::RectangleLeft;
     let function = FunctionDescriptor::Values(vec![1., 1., 1., 1., 1., 1.]);
-    let domain = vec![0.0, 0.1, 0.2, 0.3, 0.4]; // missing the last x value
-    let domain = DomainDescriptor::Explicit(&domain);
+    let domain = DomainDescriptor::Explicit(vec![0.0, 0.1, 0.2, 0.3, 0.4]);
 
     let mut integral = Integraal::default()
         .method(method)
@@ -47,7 +46,7 @@ fn inconsistent_parameters() {
         ))
     );
 
-    // this is equivalent to the first domain
+    // equivalent to the first domain
     let domain = DomainDescriptor::Uniform {
         start: 0.,
         step: 0.1,

--- a/integraal/src/tests/mod.rs
+++ b/integraal/src/tests/mod.rs
@@ -33,14 +33,14 @@ mod function_e;
 macro_rules! generate_sample_descriptors {
     ($f: ident, $d: ident, $c: ident) => {
         let $f: FunctionDescriptor<f64> = FunctionDescriptor::Closure(Box::new(|x| x));
-        let $d: DomainDescriptor<'_, f64> = DomainDescriptor::Explicit(&[]);
+        let $d: DomainDescriptor<f64> = DomainDescriptor::Explicit(vec![]);
         let $c: ComputeMethod = ComputeMethod::RectangleLeft;
     };
 }
 
 macro_rules! generate_missing {
     ($a: ident, $b: ident) => {
-        let mut integral: Integraal<'_, f64> = Integraal::default().$a($a).$b($b);
+        let mut integral: Integraal<f64> = Integraal::default().$a($a).$b($b);
         assert_eq!(
             integral.compute(),
             Err(IntegraalError::MissingParameters(
@@ -64,29 +64,6 @@ macro_rules! almost_equal {
 }
 
 macro_rules! generate_test {
-    ($ft: ty, $name: ident, $dm: stmt, $fnd: expr, $dmd: expr, $met: expr, $res: ident, $tol: ident) => {
-        #[allow(non_snake_case)]
-        #[test]
-        fn $name() {
-            $dm
-
-            let functiond = $fnd;
-            let domaind = $dmd;
-            let computem = $met;
-            let mut integraal = Integraal::default()
-                .function(functiond)
-                .domain(domaind)
-                .method(computem);
-            let res = integraal.compute();
-            assert!(res.is_ok());
-            assert!(
-                almost_equal!($ft, res.unwrap(), $res, $tol),
-                "left: {} \nright: {}",
-                res.unwrap(),
-                $res,
-            );
-        }
-    };
     ($ft: ty, $name: ident, $fnd: expr, $dmd: expr, $met: expr, $res: ident, $tol: ident) => {
         #[allow(non_snake_case)]
         #[test]
@@ -112,14 +89,10 @@ macro_rules! generate_test {
 macro_rules! all_tests {
     (
       $ft: ty,           // float type
-      $dm: stmt,         // domain
       $fnd_cls: expr,    // function descriptor (closure)
       $fnd_val: expr,    // function descriptor (values)
       $dmd_xpl: expr,    // domain descriptor (explicit)
       $dmd_uni: expr,    // domain descriptor (uniform)
-      // $met: expr,     // compute method
-      // $res: ident,    // expected result
-      // $tol: ident     // tolerance
     ) => {
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         mod rectangle_left {
@@ -128,7 +101,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ClosureExplicit,
-                $dm,
                 $fnd_cls,
                 $dmd_xpl,
                 ComputeMethod::RectangleLeft,
@@ -149,7 +121,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ValuesExplicit,
-                $dm,
                 $fnd_val,
                 $dmd_xpl,
                 ComputeMethod::RectangleLeft,
@@ -175,7 +146,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ClosureExplicit,
-                $dm,
                 $fnd_cls,
                 $dmd_xpl,
                 ComputeMethod::RectangleRight,
@@ -196,7 +166,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ValuesExplicit,
-                $dm,
                 $fnd_val,
                 $dmd_xpl,
                 ComputeMethod::RectangleRight,
@@ -222,7 +191,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ClosureExplicit,
-                $dm,
                 $fnd_cls,
                 $dmd_xpl,
                 ComputeMethod::Trapezoid,
@@ -243,7 +211,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ValuesExplicit,
-                $dm,
                 $fnd_val,
                 $dmd_xpl,
                 ComputeMethod::Trapezoid,
@@ -269,7 +236,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ClosureExplicit,
-                $dm,
                 $fnd_cls,
                 $dmd_xpl,
                 ComputeMethod::Simpson,
@@ -290,7 +256,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ValuesExplicit,
-                $dm,
                 $fnd_val,
                 $dmd_xpl,
                 ComputeMethod::Simpson,
@@ -369,7 +334,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ClosureExplicit,
-                $dm,
                 $fnd_cls,
                 $dmd_xpl,
                 ComputeMethod::MonteCarlo { n_sample: 100 },
@@ -390,7 +354,6 @@ macro_rules! all_tests {
             generate_test!(
                 $ft,
                 ValuesExplicit,
-                $dm,
                 $fnd_val,
                 $dmd_xpl,
                 ComputeMethod::MonteCarlo { n_sample: 100 },


### PR DESCRIPTION
- title
- update tests accordingly